### PR TITLE
Fix cppmunge-compilation on FreeBSD.

### DIFF
--- a/src/pal/tools/cppmunge/cppmunge.c
+++ b/src/pal/tools/cppmunge/cppmunge.c
@@ -36,7 +36,9 @@
 #include <assert.h>
 #include <ctype.h>
 #if !defined(__APPLE__)
+#ifdef __LINUX__
 #include <linux/limits.h>
+#endif
 #endif
 #include <limits.h>
 #include <stdio.h>


### PR DESCRIPTION
Only add Linux-specific stuff when on Linux.