### PR TITLE
Define PAL_CS_NATIVE_DATA_SIZE for FreeBSD x86_64

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -2998,6 +2998,8 @@ PAL_GetStackLimit();
 
 #if defined(__FreeBSD__) && defined(_X86_)
 #define PAL_CS_NATIVE_DATA_SIZE 12
+#elif defined(__FreeBSD__) && defined(__x86_64__)
+#define PAL_CS_NATIVE_DATA_SIZE 24
 #elif defined(__sun__)
 #define PAL_CS_NATIVE_DATA_SIZE 48
 #elif defined(__hpux__) && (defined(__hppa__) || defined (__ia64__))


### PR DESCRIPTION
I used the short program given in this thread https://github.com/dotnet/coreclr/issues/60 to determine what the size should be.